### PR TITLE
Add remote MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ The MCP registry is looked up in the following order:
 See `mcp_registry.sample.json` for an example configuration.
 Headers and query parameters may reference environment variables using the `env:` prefix.
 Use `"allowed_tools": ["*"]` to permit all tools from a server.
-When an MCP tool requires approval, the assistant will ask for confirmation.
-Reply with `y` to approve or `n` to deny before continuing your message.
+When an MCP tool requires approval, a dialog will pop up requesting confirmation.
+Use the Approve or Deny buttons before continuing.

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ The MCP registry is looked up in the following order:
 See `mcp_registry.sample.json` for an example configuration.
 Headers and query parameters may reference environment variables using the `env:` prefix.
 Use `"allowed_tools": ["*"]` to permit all tools from a server.
-When an MCP tool requires approval, a dialog will pop up requesting confirmation.
-Use the Approve or Deny buttons before continuing.
+When an MCP tool requires approval, the assistant will notify you in chat.
+Reply with `y` to approve or `n` to deny the request, optionally adding a comment after the `y` or `n`.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ Features:
    * example: download an ICS calendar file the model has created for you
 * streaming chat
 * image generation (via DALL-E 3)
+* remote MCP server support via configurable registry
+
+The MCP registry is looked up in the following order:
+1. `$OAI_CHAT_MCP_REGISTRY` if set
+2. `mcp_registry.json` in this repository
+3. `~/.oai_chat/mcp_registry.json`
+
+See `mcp_registry.sample.json` for an example configuration.
+Headers and query parameters may reference environment variables using the `env:` prefix.
+Use `"allowed_tools": ["*"]` to permit all tools from a server.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ The MCP registry is looked up in the following order:
 See `mcp_registry.sample.json` for an example configuration.
 Headers and query parameters may reference environment variables using the `env:` prefix.
 Use `"allowed_tools": ["*"]` to permit all tools from a server.
+When an MCP tool requires approval, the assistant will ask for confirmation.
+Reply with `y` to approve or `n` to deny before continuing your message.

--- a/app.py
+++ b/app.py
@@ -57,6 +57,11 @@ approval_modal_js = """
 }
 """
 
+approval_modal_css = """
+#mcp_modal { display:none; position:fixed; z-index:1000; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); justify-content:center; align-items:center; }
+#mcp_modal_inner { background:white; padding:20px; border-radius:8px; max-width:90%; }
+"""
+
 def encode_image(image_data):
     """Generates a prefix for image base64 data in the required format for the
     four known image formats: png, jpeg, gif, and webp.
@@ -548,24 +553,25 @@ with gr.Blocks(delete_cache=(86400, 86400)) as demo:
         dl_settings_button.click(None, controls, js=generate_download_settings_js("oai_chat_settings.bin", control_ids))
         ul_settings_button.click(None, None, None, js=generate_upload_settings_js(control_ids))
 
-    modal = gr.HTML("""
-        <div id='mcp_modal' style='display:none; position:fixed; z-index:1000; top:0; left:0; width:100%; height:100%;
-             background:rgba(0,0,0,0.5); justify-content:center; align-items:center;'>
-          <div style='background:white; padding:20px; border-radius:8px; max-width:90%;'>
-            <div id='mcp_modal_text' style='white-space:pre-wrap;'></div>
-            <textarea id='mcp_modal_input' rows='2' style='width:100%; margin-top:10px;' placeholder='Optional reply'></textarea>
-            <div style='text-align:right; margin-top:10px;'>
-              <button id='mcp_modal_deny'>Deny</button>
-              <button id='mcp_modal_approve'>Approve</button>
-            </div>
-          </div>
-        </div>
-        """)
+    with gr.Box(elem_id="mcp_modal", visible=False):
+        with gr.Column(elem_id="mcp_modal_inner"):
+            gr.Markdown(elem_id="mcp_modal_text")
+            mcp_modal_input = gr.Textbox(lines=2, elem_id="mcp_modal_input", placeholder="Optional reply")
+            with gr.Row():
+                gr.Button("Deny", elem_id="mcp_modal_deny")
+                gr.Button("Approve", elem_id="mcp_modal_approve")
 
-    chat = gr.ChatInterface(fn=bot, multimodal=True, additional_inputs=controls, autofocus=False, type="messages",
-                            chatbot=gr.Chatbot(elem_id="chatbot", type="messages"),
-                            textbox=gr.MultimodalTextbox(elem_id="chat_input"),
-                            js=approval_modal_js)
+    chat = gr.ChatInterface(
+        fn=bot,
+        multimodal=True,
+        additional_inputs=controls,
+        autofocus=False,
+        type="messages",
+        chatbot=gr.Chatbot(elem_id="chatbot", type="messages"),
+        textbox=gr.MultimodalTextbox(elem_id="chat_input"),
+        js=approval_modal_js,
+        css=approval_modal_css,
+    )
     chat.textbox.file_count = "multiple"
     chat.textbox.max_plain_text_length = 2**31
     chatbot = chat.chatbot

--- a/app.py
+++ b/app.py
@@ -20,6 +20,43 @@ temp_files = []
 mcp_servers = load_registry()
 pending_mcp_request = None
 
+approval_modal_js = """
+() => {
+    window.oai_mcp_modal = {
+        show: (msg) => {
+            const modal = document.getElementById('mcp_modal');
+            if (!modal) return;
+            document.getElementById('mcp_modal_text').innerText = msg;
+            modal.style.display = 'flex';
+        },
+        hide: () => {
+            const modal = document.getElementById('mcp_modal');
+            if (!modal) return;
+            modal.style.display = 'none';
+            document.getElementById('mcp_modal_input').value = '';
+        },
+        approve: () => {
+            const txt = document.getElementById('mcp_modal_input').value;
+            const tb = document.querySelector('#chat_input textarea');
+            tb.value = 'y ' + txt;
+            tb.dispatchEvent(new Event('input', {bubbles: true}));
+            window.oai_mcp_modal.hide();
+            document.querySelector('#chat_input button').click();
+        },
+        deny: () => {
+            const txt = document.getElementById('mcp_modal_input').value;
+            const tb = document.querySelector('#chat_input textarea');
+            tb.value = 'n ' + txt;
+            tb.dispatchEvent(new Event('input', {bubbles: true}));
+            window.oai_mcp_modal.hide();
+            document.querySelector('#chat_input button').click();
+        }
+    };
+    document.getElementById('mcp_modal_approve').onclick = window.oai_mcp_modal.approve;
+    document.getElementById('mcp_modal_deny').onclick = window.oai_mcp_modal.deny;
+}
+"""
+
 def encode_image(image_data):
     """Generates a prefix for image base64 data in the required format for the
     four known image formats: png, jpeg, gif, and webp.
@@ -133,7 +170,7 @@ def bot(message, history, oai_key, system_prompt, temperature, max_tokens, model
         if pending_mcp_request:
             txt = (message.get("text", "") or "").strip()
             if not txt:
-                raise gr.Error("MCP tool call awaiting confirmation. Reply with 'y' to approve or 'n' to deny, optionally followed by your message.")
+                raise gr.Error("MCP tool call awaiting confirmation. Use the dialog to approve or deny, optionally adding a message.")
             flag = txt[0].lower()
             if flag == 'y':
                 approve = True
@@ -421,8 +458,7 @@ def bot(message, history, oai_key, system_prompt, temperature, max_tokens, model
                             elif output.type == "mcp_approval_request":
                                 pending_mcp_request = _event_to_dict(output)
                                 whole_response += (f"\nMCP approval needed for {output.name}"
-                                                 f" on {output.server_label} with arguments {output.arguments}."
-                                                 " Reply with 'y' to approve or 'n' to deny.")
+                                                 f" on {output.server_label} with arguments {output.arguments}.")
                                 yield whole_response
                                 return
                             elif output.type == "mcp_call":
@@ -512,12 +548,39 @@ with gr.Blocks(delete_cache=(86400, 86400)) as demo:
         dl_settings_button.click(None, controls, js=generate_download_settings_js("oai_chat_settings.bin", control_ids))
         ul_settings_button.click(None, None, None, js=generate_upload_settings_js(control_ids))
 
-    chat = gr.ChatInterface(fn=bot, multimodal=True, additional_inputs=controls, autofocus = False, type = "messages")
+    modal = gr.HTML("""
+        <div id='mcp_modal' style='display:none; position:fixed; z-index:1000; top:0; left:0; width:100%; height:100%;
+             background:rgba(0,0,0,0.5); justify-content:center; align-items:center;'>
+          <div style='background:white; padding:20px; border-radius:8px; max-width:90%;'>
+            <div id='mcp_modal_text' style='white-space:pre-wrap;'></div>
+            <textarea id='mcp_modal_input' rows='2' style='width:100%; margin-top:10px;' placeholder='Optional reply'></textarea>
+            <div style='text-align:right; margin-top:10px;'>
+              <button id='mcp_modal_deny'>Deny</button>
+              <button id='mcp_modal_approve'>Approve</button>
+            </div>
+          </div>
+        </div>
+        """)
+
+    chat = gr.ChatInterface(fn=bot, multimodal=True, additional_inputs=controls, autofocus=False, type="messages",
+                            chatbot=gr.Chatbot(elem_id="chatbot", type="messages"),
+                            textbox=gr.MultimodalTextbox(elem_id="chat_input"),
+                            js=approval_modal_js)
     chat.textbox.file_count = "multiple"
     chat.textbox.max_plain_text_length = 2**31
     chatbot = chat.chatbot
     chatbot.show_copy_button = True
     chatbot.height = 450
+    chatbot.change(js="""
+        (hist) => {
+            if (hist && hist.length > 0) {
+                let last = hist[hist.length - 1];
+                if (last.role === 'assistant' && typeof last.content === 'string' && last.content.includes('MCP approval needed for')) {
+                    window.oai_mcp_modal.show(last.content);
+                }
+            }
+        }
+    """)
 
     if dump_controls:
         with gr.Row():

--- a/mcp_registry.py
+++ b/mcp_registry.py
@@ -1,0 +1,68 @@
+import os
+import json
+from urllib.parse import urlencode
+
+
+_SEARCH_PATHS = [
+    os.getenv("OAI_CHAT_MCP_REGISTRY"),
+    os.path.join(os.path.dirname(__file__), "mcp_registry.json"),
+    os.path.expanduser("~/.oai_chat/mcp_registry.json"),
+]
+
+
+def _merge_defaults(reg: dict) -> list[dict]:
+    defaults = reg.get("defaults", {})
+    servers = []
+    for entry in reg.get("servers", []):
+        if entry.get("url"):
+            merged = dict(defaults)
+            merged.update(entry)
+            servers.append(merged)
+        else:
+            # Local MCPs not yet supported
+            pass
+    return servers
+
+
+def load_registry() -> list[dict]:
+    for path in _SEARCH_PATHS:
+        if path and os.path.exists(path):
+            with open(path) as f:
+                return _merge_defaults(json.load(f))
+    return []
+
+
+def env_subst(values: dict, kind: str) -> dict:
+    out = {}
+    for k, v in values.items():
+        if isinstance(v, str) and v.startswith("env:"):
+            env_name = v[4:]
+            if env_name not in os.environ:
+                raise RuntimeError(f"Missing env var {env_name} for MCP {kind} {k}")
+            out[k] = os.environ[env_name]
+        else:
+            out[k] = v
+    return out
+
+
+def to_openai_tool(entry: dict) -> dict:
+    server_url = entry["url"]
+    if "query_params" in entry:
+        qp = urlencode(env_subst(entry["query_params"], "query parameter"))
+        if "?" in server_url:
+            server_url += "&" + qp
+        else:
+            server_url += "?" + qp
+    tool = {
+        "type": "mcp",
+        "server_label": entry.get("server_label", entry["name"]),
+        "server_url": server_url,
+        "headers": env_subst(entry.get("headers", {}), "header"),
+    }
+    if "allowed_tools" in entry:
+        allowed = entry["allowed_tools"]
+        if not (len(allowed) == 1 and allowed[0] == "*"):
+            tool["allowed_tools"] = allowed
+    if "require_approval" in entry:
+        tool["require_approval"] = entry["require_approval"]
+    return tool

--- a/mcp_registry.sample.json
+++ b/mcp_registry.sample.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0",
+
+  "defaults": {
+    "require_approval": "auto"
+  },
+
+  "servers": [
+    {
+      "name": "exa",
+      "url": "https://mcp.exa.ai/mcp",
+      "query_params": {
+        "exaApiKey": "env:EXA_API_KEY"
+      },
+      "allowed_tools": ["*"],
+      "require_approval": {
+        "never": { "tool_names": ["search"] }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- support remote MCP server registry
- parse headers with env substitution in new `mcp_registry` module
- allow selecting MCP servers via new checkboxes
- add selected MCP tools to Responses API requests
- document MCP registry support
- refine registry search and add sample file
- support query parameter authentication in MCP registry
- support wildcard `allowed_tools` entry

## Testing
- `python -m py_compile app.py mcp_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68644036e7d88324ac1ce8c279ac1878