### PR TITLE
Autofill API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/*
 .DS_Store
 .venv/
+.env

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import gradio as gr
 import base64
 import os
+from pathlib import Path
 from openai import OpenAI
 import json
 from PIL import Image
@@ -19,6 +20,22 @@ log_to_console = False
 
 mcp_servers = load_registry()
 pending_mcp_request = None
+
+def load_openai_api_key():
+    key = os.environ.get("OPENAI_API_KEY")
+    if key:
+        return key
+    env_path = Path(".env")
+    if env_path.is_file():
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                k, sep, v = line.partition("=")
+                if k == "OPENAI_API_KEY" and sep:
+                    return v.strip().strip('"').strip("'")
+    return ""
 
 def encode_image(image_data):
     """Generates a prefix for image base64 data in the required format for the
@@ -595,7 +612,7 @@ with gr.Blocks(delete_cache=(86400, 86400)) as demo:
                     Third party terms and conditions apply, particularly
                     those of the LLM vendor (OpenAI) and hosting provider (Hugging Face). This app and the AI models may make mistakes, so verify any outputs.""")
 
-        oai_key = gr.Textbox(label="OpenAI API Key", elem_id="oai_key")
+        oai_key = gr.Textbox(label="OpenAI API Key", elem_id="oai_key", value=load_openai_api_key())
         model = gr.Dropdown(label="Model", value="gpt-4.1", allow_custom_value=True, elem_id="model",
                             choices=["gpt-4o", "gpt-4.1", "gpt-4.5-preview", "o3", "o3-high", "o1-pro", "o1-high", "o1-mini", "o1", "o3-mini-high", "o3-mini", "o4-mini", "o4-mini-high", "chatgpt-4o-latest", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "whisper", "gpt-image-1"])
         system_prompt = gr.TextArea("You are a helpful yet diligent AI assistant. Answer faithfully and factually correct. Respond with 'I do not know' if uncertain.", label="System/Developer Prompt", lines=3, max_lines=250, elem_id="system_prompt")  


### PR DESCRIPTION
## Summary
- let `.env` file be ignored by git
- populate the OpenAI key textbox with value from environment or `.env`

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile app.py mcp_registry.py chat_export.py settings_mgr.py doc2json.py code_exec.py`


------
https://chatgpt.com/codex/tasks/task_e_686a26073c308324a19d6a335830c420